### PR TITLE
Rely on `@checked` in OverflowContexts and reexport

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.2.0"
 CheckedArithmeticCore = "740b204e-26e5-40b1-866a-9c367e60c4b6"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OverflowContexts = "649716ba-0eb1-4560-ace2-251185f55281"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CheckedArithmetic"
 uuid = "2c4a1fb8-30c1-4c71-8b84-dff8d59868ee"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 CheckedArithmeticCore = "740b204e-26e5-40b1-866a-9c367e60c4b6"
@@ -13,6 +13,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 CheckedArithmeticCore = "0.1"
 julia = "1"
+OverflowContexts = "0.2.4"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ will not detect overflow caused by `f`.
 The [`Base.Checked` module](https://github.com/JuliaLang/julia/blob/master/base/checked.jl) defines numerous checked operations.
 These can be specialized for custom types.
 
+**Note:** `@checked` originates from [OverflowContexts.jl](https://github.com/JuliaMath/OverflowContexts.jl) as of v0.2.1, which includes other functionality not exposed in this package.
+
 ## `@check`
 
 `@check` performs an operation in two different ways,

--- a/src/CheckedArithmetic.jl
+++ b/src/CheckedArithmetic.jl
@@ -16,9 +16,7 @@ using Dates
 
 export @check
 export accumulatortype, acc # re-export
-export @default_checked, @default_unchecked, @checked, @unchecked,
-    unchecked_neg, unchecked_add, unchecked_sub, unchecked_mul, unchecked_negsub, unchecked_pow, unchecked_abs,
-    checked_neg, checked_add, checked_sub, checked_mul, checked_pow, checked_negsub, checked_abs # re-export
+export @checked, checked_neg, checked_add, checked_sub, checked_mul, checked_pow, checked_negsub, checked_abs # re-export
 
 macro check(expr, kws...)
     isexpr(expr, :call) || error("expected :call expression, got ",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,11 +8,6 @@ Pkg.test("CheckedArithmeticCore")
 
 @test isempty(detect_ambiguities(CheckedArithmetic, Base, Core))
 
-@checked begin
-    plus(x, y) = x + y
-    minus(x, y) = x - y
-end
-
 function sumsquares(A::AbstractArray)
     s = zero(accumulatortype(eltype(A)))
     for a in A
@@ -23,20 +18,8 @@ end
 
 @testset "CheckedArithmetic.jl" begin
     @testset "@checked" begin
-        @test @checked(abs(Int8(-2))) === Int8(2)
-        @test_throws OverflowError @checked(abs(typemin(Int8)))
-        @test @checked(+2) === 2
-        @test @checked(+UInt(2)) === UInt(2)
-        @test @checked(-2) === -2
-        @test_throws OverflowError @checked(-UInt(2))
-        @test @checked(0x10 + 0x20) === 0x30
-        @test_throws OverflowError @checked(0xf0 + 0x20)
-        @test @checked(0x30 - 0x20) === 0x10
-        @test_throws OverflowError @checked(0x10 - 0x20)
-        @test @checked(-7) === -7
-        @test_throws OverflowError @checked(-UInt(7))
-        @test @checked(0x10*0x02) === 0x20
-        @test_throws OverflowError @checked(0x10*0x10)
+        # Julia errors by default, so this is just for security.
+        # OverflowContexts does not test for this.
         @test @checked(7 ÷ 2) === 3
         @test_throws DivideError @checked(typemin(Int8)÷Int8(-1))
         @test @checked(div(0x7, 0x2)) === 0x3
@@ -51,11 +34,6 @@ end
         @test_throws DivideError @checked(mod(typemin(Int8), Int8(0)))
         @test @checked(cld(typemax(Int8), Int8(-1))) === -typemax(Int8)
         @test_throws DivideError @checked(cld(typemin(Int8), Int8(-1)))
-
-        @test plus(0x10, 0x20) === 0x30
-        @test_throws OverflowError plus(0xf0, 0x20)
-        @test minus(0x30, 0x20) === 0x10
-        @test_throws OverflowError minus(0x20, 0x30)
     end
 
     @testset "@check" begin


### PR DESCRIPTION
As discussed in #12, merging some of the functionality of this package with OverflowContexts (https://github.com/JuliaMath/OverflowContexts.jl) is desired, as is using its name. The name is also preferred for that portion, as it would be inclusive of other modes, e.g., saturating math.

OverflowContexts. expanded the `@checked` macro of this package and expanded it to include other features including `@unchecked`, allowing these to be arbitrarily nested, and providing the capability to set a default for a module with `@default_checked` and `@default_unchecked` at the top of a module. It also fixes some limitations with the implementation here.

This PR removes the portions that are present in OverflowContexts and adds OverflowContexts as a dependency (starting with newly-registered v0.2.4).

All tests of this package passed with the dependency added and the native macro removed before I removed those specific tests here. For compatibility, CheckedArithmetic will re-exports the portions of OverflowContexts necessary for there to be no break for users of CheckedArithmetic.